### PR TITLE
✨  Feature – Add support for batching SQL requests

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -13,7 +13,8 @@
             "elm/random": "1.0.0",
             "elm/time": "1.0.0",
             "elm-community/json-extra": "4.3.0",
-            "elm-community/list-extra": "8.5.2"
+            "elm-community/list-extra": "8.5.2",
+            "pzp1997/assoc-list": "1.0.0"
         },
         "indirect": {
             "elm/parser": "1.1.0",

--- a/src/GraphQL/Info.elm
+++ b/src/GraphQL/Info.elm
@@ -1,4 +1,4 @@
-module GraphQL.Info exposing (Info, fromJson, hasSelection, toPathId)
+module GraphQL.Info exposing (Info, fromJson, hasSelection, toBatchId)
 
 import Json.Decode
 import Json.Encode
@@ -9,7 +9,7 @@ type Info
 
 
 type alias Internals =
-    { pathId : String -- Example "posts.author"
+    { batchId : String -- Example "posts.author"
     , uniquePathId : String -- Example "posts.[0].author"
     , selections : List String
     }
@@ -28,7 +28,7 @@ fromJson fieldName json =
 fallback : Info
 fallback =
     Info
-        { pathId = ""
+        { batchId = ""
         , uniquePathId = ""
         , selections = []
         }
@@ -144,6 +144,6 @@ hasSelection field (Info info) =
     List.member field info.selections
 
 
-toPathId : Info -> String
-toPathId (Info info) =
-    info.pathId
+toBatchId : Info -> String
+toBatchId (Info info) =
+    info.batchId

--- a/src/GraphQL/Response.elm
+++ b/src/GraphQL/Response.elm
@@ -91,7 +91,7 @@ fromDatabaseQuery query =
 
 toCmd :
     { onSuccess : value -> Cmd msg
-    , onFailure : Json.Decode.Value -> Cmd msg
+    , onFailure : String -> Cmd msg
     , onDatabaseQuery :
         { sql : String
         , onResponse : Json.Decode.Value -> Cmd msg
@@ -106,7 +106,7 @@ toCmd options response =
             options.onSuccess value
 
         Failure reason ->
-            options.onFailure (Json.Encode.string reason)
+            options.onFailure reason
 
         Query query ->
             sendMessage

--- a/src/GraphQL/Response.elm
+++ b/src/GraphQL/Response.elm
@@ -146,11 +146,6 @@ map fn response =
             Failure "Batched queries do not support Response.map"
 
 
-mapList : (List a -> List b) -> Response (List a) -> Response (List b)
-mapList =
-    map
-
-
 andThen : (a -> Response b) -> Response a -> Response b
 andThen toResponse response =
     case response of
@@ -168,11 +163,6 @@ andThen toResponse response =
 
         Batch data ->
             Failure "Batched queries do not support Response.andThen"
-
-
-andThenList : (List a -> Response (List b)) -> Response (List a) -> Response (List b)
-andThenList =
-    andThen
 
 
 toCmd :

--- a/src/GraphQL/Response.elm
+++ b/src/GraphQL/Response.elm
@@ -166,7 +166,20 @@ andThen toResponse response =
 
 
 toCmd :
-    Options value msg
+    { onSuccess : value -> Cmd msg
+    , onFailure : String -> Cmd msg
+    , onDatabaseQuery :
+        { sql : String
+        , onResponse : Json.Decode.Value -> Cmd msg
+        }
+        -> msg
+    , onBatchQuery :
+        { id : Int
+        , info : Info
+        , onResponse : List Int -> Cmd msg
+        }
+        -> msg
+    }
     -> Response value
     -> Cmd msg
 toCmd options response =
@@ -205,29 +218,3 @@ toCmd options response =
 sendMessage : msg -> Cmd msg
 sendMessage msg =
     Task.succeed msg |> Task.perform identity
-
-
-type alias Options value msg =
-    { onSuccess : value -> Cmd msg
-    , onFailure : String -> Cmd msg
-    , onDatabaseQuery :
-        { sql : String
-        , onResponse : Json.Decode.Value -> Cmd msg
-        }
-        -> msg
-    , onBatchQuery :
-        { id : Int
-        , info : Info
-        , onResponse : List Int -> Cmd msg
-        }
-        -> msg
-    }
-
-
-mapOptions : (b -> a) -> Options a msg -> Options b msg
-mapOptions fn options =
-    { onSuccess = \b -> options.onSuccess (fn b)
-    , onFailure = options.onFailure
-    , onDatabaseQuery = options.onDatabaseQuery
-    , onBatchQuery = options.onBatchQuery
-    }

--- a/src/GraphQL/Response.elm
+++ b/src/GraphQL/Response.elm
@@ -97,7 +97,6 @@ batchList options =
                     List.Extra.getAt index listOfLists
                         |> Maybe.withDefault []
 
-                -- |> Maybe.andThen identity
                 Nothing ->
                     []
     in
@@ -143,8 +142,13 @@ map fn response =
                 , onResponse = \json -> map fn (data.onResponse json)
                 }
 
-        Batch _ ->
-            Debug.todo "batch map"
+        Batch data ->
+            Failure "Batched queries do not support Response.map"
+
+
+mapList : (List a -> List b) -> Response (List a) -> Response (List b)
+mapList =
+    map
 
 
 andThen : (a -> Response b) -> Response a -> Response b
@@ -162,8 +166,13 @@ andThen toResponse response =
                 , onResponse = \json -> andThen toResponse (data.onResponse json)
                 }
 
-        Batch _ ->
-            Debug.todo "batch andThen"
+        Batch data ->
+            Failure "Batched queries do not support Response.andThen"
+
+
+andThenList : (List a -> Response (List b)) -> Response (List a) -> Response (List b)
+andThenList =
+    andThen
 
 
 toCmd :

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -264,7 +264,7 @@ runResolver request =
             Ports.failure
                 { request = request
                 , reason =
-                    "Did not recognize {{objectName}}.{{fieldName}}"
+                    "Elm application is missing a resolver for {{objectName}}.{{fieldName}}"
                         |> String.replace "{{objectName}}" objectName
                         |> String.replace "{{fieldName}}" fieldName
                 }
@@ -272,7 +272,7 @@ runResolver request =
         Err _ ->
             Ports.failure
                 { request = request
-                , reason = "Field was not passed in."
+                , reason = "Elm expected `objectName` and `fieldName` in the request."
                 }
 
 

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -54,6 +54,13 @@ type alias Model =
 
 init : Json.Decode.Value -> ( Model, Cmd Msg )
 init flags =
+    ( { onResponse = Nothing }
+    , runResolver flags
+    )
+
+
+runResolver : Json.Decode.Value -> Cmd Msg
+runResolver request =
     let
         objectAndFieldResult : Result Json.Decode.Error ( String, String )
         objectAndFieldResult =
@@ -62,21 +69,20 @@ init flags =
                     (Json.Decode.field "objectName" Json.Decode.string)
                     (Json.Decode.field "fieldName" Json.Decode.string)
                 )
-                flags
+                request
 
         context : GraphQL.Context.Context
         context =
-            GraphQL.Context.fromJson "context" flags
+            GraphQL.Context.fromJson "context" request
 
         info : GraphQL.Info.Info
         info =
-            GraphQL.Info.fromJson "info" flags
+            GraphQL.Info.fromJson "info" request
     in
-    ( { onResponse = Nothing }
-    , case objectAndFieldResult of
+    case objectAndFieldResult of
         Ok ( "Query", "hello" ) ->
             createResolver
-                { flags = flags
+                { request = request
                 , parentDecoder = Json.Decode.succeed ()
                 , argsDecoder = Resolvers.Query.Hello.argumentDecoder
                 , resolver = Resolvers.Query.Hello.resolver
@@ -85,7 +91,7 @@ init flags =
 
         Ok ( "Query", "user" ) ->
             createResolver
-                { flags = flags
+                { request = request
                 , parentDecoder = Json.Decode.succeed ()
                 , argsDecoder = Resolvers.Query.User.argumentsDecoder
                 , resolver = Resolvers.Query.User.resolver info
@@ -94,7 +100,7 @@ init flags =
 
         Ok ( "Query", "users" ) ->
             createResolver
-                { flags = flags
+                { request = request
                 , parentDecoder = Json.Decode.succeed ()
                 , argsDecoder = Json.Decode.succeed ()
                 , resolver = Resolvers.Query.Users.resolver info
@@ -103,7 +109,7 @@ init flags =
 
         Ok ( "Query", "post" ) ->
             createResolver
-                { flags = flags
+                { request = request
                 , parentDecoder = Json.Decode.succeed ()
                 , argsDecoder = Resolvers.Query.Post.argumentsDecoder
                 , resolver = Resolvers.Query.Post.resolver info
@@ -112,7 +118,7 @@ init flags =
 
         Ok ( "Query", "posts" ) ->
             createResolver
-                { flags = flags
+                { request = request
                 , parentDecoder = Json.Decode.succeed ()
                 , argsDecoder = Json.Decode.succeed ()
                 , resolver = Resolvers.Query.Posts.resolver info
@@ -121,7 +127,7 @@ init flags =
 
         Ok ( "Mutation", "createPost" ) ->
             createResolver
-                { flags = flags
+                { request = request
                 , parentDecoder = Json.Decode.succeed ()
                 , argsDecoder = Resolvers.Mutation.CreatePost.argumentsDecoder
                 , resolver = Resolvers.Mutation.CreatePost.resolver info context
@@ -130,7 +136,7 @@ init flags =
 
         Ok ( "Mutation", "updatePost" ) ->
             createResolver
-                { flags = flags
+                { request = request
                 , parentDecoder = Json.Decode.succeed ()
                 , argsDecoder = Resolvers.Mutation.UpdatePost.argumentsDecoder
                 , resolver = Resolvers.Mutation.UpdatePost.resolver info
@@ -139,7 +145,7 @@ init flags =
 
         Ok ( "Mutation", "deletePost" ) ->
             createResolver
-                { flags = flags
+                { request = request
                 , parentDecoder = Json.Decode.succeed ()
                 , argsDecoder = Resolvers.Mutation.DeletePost.argumentsDecoder
                 , resolver = Resolvers.Mutation.DeletePost.resolver info
@@ -148,7 +154,7 @@ init flags =
 
         Ok ( "Mutation", "createUser" ) ->
             createResolver
-                { flags = flags
+                { request = request
                 , parentDecoder = Json.Decode.succeed ()
                 , argsDecoder = Resolvers.Mutation.CreateUser.argumentsDecoder
                 , resolver = Resolvers.Mutation.CreateUser.resolver info
@@ -157,7 +163,7 @@ init flags =
 
         Ok ( "Mutation", "updateUser" ) ->
             createResolver
-                { flags = flags
+                { request = request
                 , parentDecoder = Json.Decode.succeed ()
                 , argsDecoder = Resolvers.Mutation.UpdateUser.argumentsDecoder
                 , resolver = Resolvers.Mutation.UpdateUser.resolver info
@@ -166,7 +172,7 @@ init flags =
 
         Ok ( "Mutation", "deleteUser" ) ->
             createResolver
-                { flags = flags
+                { request = request
                 , parentDecoder = Json.Decode.succeed ()
                 , argsDecoder = Resolvers.Mutation.DeleteUser.argumentsDecoder
                 , resolver = Resolvers.Mutation.DeleteUser.resolver info
@@ -175,7 +181,7 @@ init flags =
 
         Ok ( "User", "id" ) ->
             createResolver
-                { flags = flags
+                { request = request
                 , parentDecoder = Schema.User.decoder
                 , argsDecoder = Json.Decode.succeed ()
                 , resolver = Resolvers.User.Id.resolver
@@ -184,7 +190,7 @@ init flags =
 
         Ok ( "User", "username" ) ->
             createResolver
-                { flags = flags
+                { request = request
                 , parentDecoder = Schema.User.decoder
                 , argsDecoder = Json.Decode.succeed ()
                 , resolver = Resolvers.User.Username.resolver
@@ -193,7 +199,7 @@ init flags =
 
         Ok ( "User", "avatarUrl" ) ->
             createResolver
-                { flags = flags
+                { request = request
                 , parentDecoder = Schema.User.decoder
                 , argsDecoder = Json.Decode.succeed ()
                 , resolver = Resolvers.User.AvatarUrl.resolver
@@ -202,7 +208,7 @@ init flags =
 
         Ok ( "User", "posts" ) ->
             createResolver
-                { flags = flags
+                { request = request
                 , parentDecoder = Schema.User.decoder
                 , argsDecoder = Json.Decode.succeed ()
                 , resolver = Resolvers.User.Posts.resolver
@@ -211,7 +217,7 @@ init flags =
 
         Ok ( "Post", "id" ) ->
             createResolver
-                { flags = flags
+                { request = request
                 , parentDecoder = Schema.Post.decoder
                 , argsDecoder = Json.Decode.succeed ()
                 , resolver = Resolvers.Post.Id.resolver
@@ -220,7 +226,7 @@ init flags =
 
         Ok ( "Post", "imageUrls" ) ->
             createResolver
-                { flags = flags
+                { request = request
                 , parentDecoder = Schema.Post.decoder
                 , argsDecoder = Json.Decode.succeed ()
                 , resolver = Resolvers.Post.ImageUrls.resolver
@@ -229,7 +235,7 @@ init flags =
 
         Ok ( "Post", "caption" ) ->
             createResolver
-                { flags = flags
+                { request = request
                 , parentDecoder = Schema.Post.decoder
                 , argsDecoder = Json.Decode.succeed ()
                 , resolver = Resolvers.Post.Caption.resolver
@@ -238,7 +244,7 @@ init flags =
 
         Ok ( "Post", "createdAt" ) ->
             createResolver
-                { flags = flags
+                { request = request
                 , parentDecoder = Schema.Post.decoder
                 , argsDecoder = Json.Decode.succeed ()
                 , resolver = Resolvers.Post.CreatedAt.resolver
@@ -247,7 +253,7 @@ init flags =
 
         Ok ( "Post", "author" ) ->
             createResolver
-                { flags = flags
+                { request = request
                 , parentDecoder = Schema.Post.decoder
                 , argsDecoder = Json.Decode.succeed ()
                 , resolver = Resolvers.Post.Author.resolver
@@ -256,20 +262,22 @@ init flags =
 
         Ok ( objectName, fieldName ) ->
             Ports.failure
-                (Json.Encode.string
-                    ("Did not recognize {{objectName}}.{{fieldName}}"
+                { request = request
+                , reason =
+                    "Did not recognize {{objectName}}.{{fieldName}}"
                         |> String.replace "{{objectName}}" objectName
                         |> String.replace "{{fieldName}}" fieldName
-                    )
-                )
+                }
 
         Err _ ->
-            Ports.failure (Json.Encode.string "Field was not passed in.")
-    )
+            Ports.failure
+                { request = request
+                , reason = "Field was not passed in."
+                }
 
 
 createResolver :
-    { flags : Json.Decode.Value
+    { request : Json.Decode.Value
     , parentDecoder : Json.Decode.Decoder parent
     , argsDecoder : Json.Decode.Decoder args
     , resolver : parent -> args -> Response value
@@ -284,18 +292,30 @@ createResolver options =
                 (Json.Decode.field "parent" options.parentDecoder)
                 (Json.Decode.field "args" options.argsDecoder)
     in
-    case Json.Decode.decodeValue inputDecoder options.flags of
+    case Json.Decode.decodeValue inputDecoder options.request of
         Ok { parent, args } ->
             options.resolver parent args
                 |> GraphQL.Response.toCmd
-                    { onSuccess = options.toJson >> Ports.success
-                    , onFailure = Ports.failure
-                    , onDatabaseQuery = ResolverSentDatabaseQuery
+                    { onSuccess =
+                        \value ->
+                            Ports.success
+                                { request = options.request
+                                , value = options.toJson value
+                                }
+                    , onFailure =
+                        \reason ->
+                            Ports.failure
+                                { request = options.request
+                                , reason = reason
+                                }
+                    , onDatabaseQuery = ResolverSentDatabaseQuery options.request
                     }
 
         Err _ ->
-            Json.Encode.string "Failed to decode parent/args."
-                |> Ports.failure
+            Ports.failure
+                { request = options.request
+                , reason = "Failed to decode parent/args."
+                }
 
 
 
@@ -304,23 +324,28 @@ createResolver options =
 
 type Msg
     = ResolverSentDatabaseQuery
+        Json.Decode.Value
         { sql : String
         , onResponse : Json.Decode.Value -> Cmd Msg
         }
     | JavascriptSentDatabaseResponse
-        { response : Json.Decode.Value
+        { request : Json.Decode.Value
+        , response : Json.Decode.Value
         }
 
 
 update : Msg -> Model -> ( Model, Cmd Msg )
 update msg model =
     case msg of
-        ResolverSentDatabaseQuery options ->
+        ResolverSentDatabaseQuery request options ->
             ( { model | onResponse = Just options.onResponse }
-            , Ports.databaseOut { sql = options.sql }
+            , Ports.databaseOut
+                { request = request
+                , sql = options.sql
+                }
             )
 
-        JavascriptSentDatabaseResponse { response } ->
+        JavascriptSentDatabaseResponse { request, response } ->
             case model.onResponse of
                 Just onResponse ->
                     ( { model | onResponse = Nothing }
@@ -329,7 +354,10 @@ update msg model =
 
                 Nothing ->
                     ( model
-                    , Ports.failure (Json.Encode.string "Unexpected response from the database.")
+                    , Ports.failure
+                        { request = request
+                        , reason = "Unexpected response from the database."
+                        }
                     )
 
 

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -35,7 +35,7 @@ import Schema.User
 import Time
 
 
-main : Program Json.Decode.Value Model Msg
+main : Program () Model Msg
 main =
     Platform.worker
         { init = init
@@ -48,14 +48,22 @@ main =
 -- INIT
 
 
+type alias ResolverId =
+    String
+
+
+type alias BatchResolverId =
+    String
+
+
 type alias Model =
-    { batchResponseDict : Dict String (List Int -> Cmd Msg)
-    , databaseResponseDict : AssocList.Dict Json.Decode.Value (Json.Decode.Value -> Cmd Msg)
+    { batchResponseDict : Dict BatchResolverId (List (List Int -> Cmd Msg))
+    , databaseResponseDict : AssocList.Dict ResolverId (Json.Decode.Value -> Cmd Msg)
     }
 
 
-init : Json.Decode.Value -> ( Model, Cmd Msg )
-init flags =
+init : () -> ( Model, Cmd Msg )
+init () =
     ( { batchResponseDict = Dict.empty
       , databaseResponseDict = AssocList.empty
       }
@@ -63,8 +71,8 @@ init flags =
     )
 
 
-runResolver : Json.Decode.Value -> Cmd Msg
-runResolver request =
+runResolver : ResolverId -> Json.Decode.Value -> Cmd Msg
+runResolver resolverId request =
     let
         objectAndFieldResult : Result Json.Decode.Error ( String, String )
         objectAndFieldResult =
@@ -86,7 +94,8 @@ runResolver request =
     case objectAndFieldResult of
         Ok ( "Query", "hello" ) ->
             createResolver
-                { request = request
+                { resolverId = resolverId
+                , request = request
                 , parentDecoder = Json.Decode.succeed ()
                 , argsDecoder = Resolvers.Query.Hello.argumentDecoder
                 , resolver = Resolvers.Query.Hello.resolver
@@ -95,7 +104,8 @@ runResolver request =
 
         Ok ( "Query", "user" ) ->
             createResolver
-                { request = request
+                { resolverId = resolverId
+                , request = request
                 , parentDecoder = Json.Decode.succeed ()
                 , argsDecoder = Resolvers.Query.User.argumentsDecoder
                 , resolver = Resolvers.Query.User.resolver info
@@ -104,7 +114,8 @@ runResolver request =
 
         Ok ( "Query", "users" ) ->
             createResolver
-                { request = request
+                { resolverId = resolverId
+                , request = request
                 , parentDecoder = Json.Decode.succeed ()
                 , argsDecoder = Json.Decode.succeed ()
                 , resolver = Resolvers.Query.Users.resolver info
@@ -113,7 +124,8 @@ runResolver request =
 
         Ok ( "Query", "post" ) ->
             createResolver
-                { request = request
+                { resolverId = resolverId
+                , request = request
                 , parentDecoder = Json.Decode.succeed ()
                 , argsDecoder = Resolvers.Query.Post.argumentsDecoder
                 , resolver = Resolvers.Query.Post.resolver info
@@ -122,7 +134,8 @@ runResolver request =
 
         Ok ( "Query", "posts" ) ->
             createResolver
-                { request = request
+                { resolverId = resolverId
+                , request = request
                 , parentDecoder = Json.Decode.succeed ()
                 , argsDecoder = Json.Decode.succeed ()
                 , resolver = Resolvers.Query.Posts.resolver
@@ -131,7 +144,8 @@ runResolver request =
 
         Ok ( "Mutation", "createPost" ) ->
             createResolver
-                { request = request
+                { resolverId = resolverId
+                , request = request
                 , parentDecoder = Json.Decode.succeed ()
                 , argsDecoder = Resolvers.Mutation.CreatePost.argumentsDecoder
                 , resolver = Resolvers.Mutation.CreatePost.resolver info context
@@ -140,7 +154,8 @@ runResolver request =
 
         Ok ( "Mutation", "updatePost" ) ->
             createResolver
-                { request = request
+                { resolverId = resolverId
+                , request = request
                 , parentDecoder = Json.Decode.succeed ()
                 , argsDecoder = Resolvers.Mutation.UpdatePost.argumentsDecoder
                 , resolver = Resolvers.Mutation.UpdatePost.resolver info
@@ -149,7 +164,8 @@ runResolver request =
 
         Ok ( "Mutation", "deletePost" ) ->
             createResolver
-                { request = request
+                { resolverId = resolverId
+                , request = request
                 , parentDecoder = Json.Decode.succeed ()
                 , argsDecoder = Resolvers.Mutation.DeletePost.argumentsDecoder
                 , resolver = Resolvers.Mutation.DeletePost.resolver info
@@ -158,7 +174,8 @@ runResolver request =
 
         Ok ( "Mutation", "createUser" ) ->
             createResolver
-                { request = request
+                { resolverId = resolverId
+                , request = request
                 , parentDecoder = Json.Decode.succeed ()
                 , argsDecoder = Resolvers.Mutation.CreateUser.argumentsDecoder
                 , resolver = Resolvers.Mutation.CreateUser.resolver info
@@ -167,7 +184,8 @@ runResolver request =
 
         Ok ( "Mutation", "updateUser" ) ->
             createResolver
-                { request = request
+                { resolverId = resolverId
+                , request = request
                 , parentDecoder = Json.Decode.succeed ()
                 , argsDecoder = Resolvers.Mutation.UpdateUser.argumentsDecoder
                 , resolver = Resolvers.Mutation.UpdateUser.resolver info
@@ -176,7 +194,8 @@ runResolver request =
 
         Ok ( "Mutation", "deleteUser" ) ->
             createResolver
-                { request = request
+                { resolverId = resolverId
+                , request = request
                 , parentDecoder = Json.Decode.succeed ()
                 , argsDecoder = Resolvers.Mutation.DeleteUser.argumentsDecoder
                 , resolver = Resolvers.Mutation.DeleteUser.resolver info
@@ -185,7 +204,8 @@ runResolver request =
 
         Ok ( "User", "id" ) ->
             createResolver
-                { request = request
+                { resolverId = resolverId
+                , request = request
                 , parentDecoder = Schema.User.decoder
                 , argsDecoder = Json.Decode.succeed ()
                 , resolver = Resolvers.User.Id.resolver
@@ -194,7 +214,8 @@ runResolver request =
 
         Ok ( "User", "username" ) ->
             createResolver
-                { request = request
+                { resolverId = resolverId
+                , request = request
                 , parentDecoder = Schema.User.decoder
                 , argsDecoder = Json.Decode.succeed ()
                 , resolver = Resolvers.User.Username.resolver
@@ -203,7 +224,8 @@ runResolver request =
 
         Ok ( "User", "avatarUrl" ) ->
             createResolver
-                { request = request
+                { resolverId = resolverId
+                , request = request
                 , parentDecoder = Schema.User.decoder
                 , argsDecoder = Json.Decode.succeed ()
                 , resolver = Resolvers.User.AvatarUrl.resolver
@@ -212,7 +234,8 @@ runResolver request =
 
         Ok ( "User", "posts" ) ->
             createResolver
-                { request = request
+                { resolverId = resolverId
+                , request = request
                 , parentDecoder = Schema.User.decoder
                 , argsDecoder = Json.Decode.succeed ()
                 , resolver = Resolvers.User.Posts.resolver
@@ -221,7 +244,8 @@ runResolver request =
 
         Ok ( "Post", "id" ) ->
             createResolver
-                { request = request
+                { resolverId = resolverId
+                , request = request
                 , parentDecoder = Schema.Post.decoder
                 , argsDecoder = Json.Decode.succeed ()
                 , resolver = Resolvers.Post.Id.resolver
@@ -230,7 +254,8 @@ runResolver request =
 
         Ok ( "Post", "imageUrls" ) ->
             createResolver
-                { request = request
+                { resolverId = resolverId
+                , request = request
                 , parentDecoder = Schema.Post.decoder
                 , argsDecoder = Json.Decode.succeed ()
                 , resolver = Resolvers.Post.ImageUrls.resolver
@@ -239,7 +264,8 @@ runResolver request =
 
         Ok ( "Post", "caption" ) ->
             createResolver
-                { request = request
+                { resolverId = resolverId
+                , request = request
                 , parentDecoder = Schema.Post.decoder
                 , argsDecoder = Json.Decode.succeed ()
                 , resolver = Resolvers.Post.Caption.resolver
@@ -248,7 +274,8 @@ runResolver request =
 
         Ok ( "Post", "createdAt" ) ->
             createResolver
-                { request = request
+                { resolverId = resolverId
+                , request = request
                 , parentDecoder = Schema.Post.decoder
                 , argsDecoder = Json.Decode.succeed ()
                 , resolver = Resolvers.Post.CreatedAt.resolver
@@ -257,7 +284,8 @@ runResolver request =
 
         Ok ( "Post", "author" ) ->
             createResolver
-                { request = request
+                { resolverId = resolverId
+                , request = request
                 , parentDecoder = Schema.Post.decoder
                 , argsDecoder = Json.Decode.succeed ()
                 , resolver = Resolvers.Post.Author.resolver info
@@ -266,7 +294,7 @@ runResolver request =
 
         Ok ( objectName, fieldName ) ->
             Ports.failure
-                { request = request
+                { resolverId = resolverId
                 , reason =
                     "Elm application is missing a resolver for {{objectName}}.{{fieldName}}"
                         |> String.replace "{{objectName}}" objectName
@@ -275,13 +303,14 @@ runResolver request =
 
         Err _ ->
             Ports.failure
-                { request = request
+                { resolverId = resolverId
                 , reason = "Elm expected `objectName` and `fieldName` in the request."
                 }
 
 
 createResolver :
-    { request : Json.Decode.Value
+    { resolverId : ResolverId
+    , request : Json.Decode.Value
     , parentDecoder : Json.Decode.Decoder parent
     , argsDecoder : Json.Decode.Decoder args
     , resolver : parent -> args -> Response value
@@ -303,22 +332,22 @@ createResolver options =
                     { onSuccess =
                         \value ->
                             Ports.success
-                                { request = options.request
+                                { resolverId = options.resolverId
                                 , value = options.toJson value
                                 }
                     , onFailure =
                         \reason ->
                             Ports.failure
-                                { request = options.request
+                                { resolverId = options.resolverId
                                 , reason = reason
                                 }
-                    , onDatabaseQuery = ElmSentDatabaseQuery options.request
-                    , onBatchQuery = ElmSentBatchRequest options.request
+                    , onDatabaseQuery = ElmSentDatabaseQuery options.resolverId
+                    , onBatchQuery = ElmSentBatchRequest options.resolverId
                     }
 
         Err _ ->
             Ports.failure
-                { request = options.request
+                { resolverId = options.resolverId
                 , reason = "Failed to decode parent/args."
                 }
 
@@ -329,27 +358,28 @@ createResolver options =
 
 type Msg
     = ElmSentDatabaseQuery
-        Json.Decode.Value
+        ResolverId
         { sql : String
         , onResponse : Json.Decode.Value -> Cmd Msg
         }
     | ElmSentBatchRequest
-        Json.Decode.Value
+        ResolverId
         { id : Int
         , info : Info
         , onResponse : List Int -> Cmd Msg
         }
     | JavascriptSentDatabaseResponse
-        { request : Json.Decode.Value
+        { resolverId : ResolverId
         , response : Json.Decode.Value
         }
     | JavascriptSentBatchResponse
-        { request : Json.Decode.Value
-        , pathId : String
+        { resolverId : ResolverId
+        , pathId : BatchResolverId
         , ids : List Int
         }
     | JavascriptRequestedResolver
-        { request : Json.Decode.Value
+        { resolverId : ResolverId
+        , request : Json.Decode.Value
         }
 
 
@@ -357,54 +387,62 @@ update : Msg -> Model -> ( Model, Cmd Msg )
 update msg model =
     case msg of
         -- case Debug.log "msg" msg of
-        ElmSentDatabaseQuery request options ->
-            ( { model | databaseResponseDict = AssocList.insert request options.onResponse model.databaseResponseDict }
+        ElmSentDatabaseQuery resolverId options ->
+            ( { model | databaseResponseDict = AssocList.insert resolverId options.onResponse model.databaseResponseDict }
             , Ports.databaseOut
-                { request = request
+                { resolverId = resolverId
                 , sql = options.sql
                 }
             )
 
-        ElmSentBatchRequest request options ->
-            ( { model | batchResponseDict = Dict.insert (GraphQL.Info.toPathId options.info) options.onResponse model.batchResponseDict }
+        ElmSentBatchRequest resolverId options ->
+            let
+                addCmdToList : Maybe (List (List Int -> Cmd Msg)) -> Maybe (List (List Int -> Cmd Msg))
+                addCmdToList maybeList =
+                    maybeList
+                        |> Maybe.withDefault []
+                        |> (\list -> options.onResponse :: list)
+                        |> Just
+            in
+            ( { model | batchResponseDict = Dict.update (GraphQL.Info.toPathId options.info) addCmdToList model.batchResponseDict }
             , Ports.batchRequestOut
-                { request = request
+                { resolverId = resolverId
                 , id = options.id
                 , pathId = GraphQL.Info.toPathId options.info
                 }
             )
 
-        JavascriptRequestedResolver { request } ->
+        JavascriptRequestedResolver { resolverId, request } ->
             ( model
-            , runResolver request
+            , runResolver resolverId request
             )
 
-        JavascriptSentDatabaseResponse { request, response } ->
-            case AssocList.get request model.databaseResponseDict of
+        JavascriptSentDatabaseResponse { resolverId, response } ->
+            case AssocList.get resolverId model.databaseResponseDict of
                 Just onResponse ->
-                    ( { model | databaseResponseDict = AssocList.remove request model.databaseResponseDict }
+                    ( { model | databaseResponseDict = AssocList.remove resolverId model.databaseResponseDict }
                     , onResponse response
                     )
 
                 Nothing ->
                     ( model
                     , Ports.failure
-                        { request = request
+                        { resolverId = resolverId
                         , reason = "Unexpected database response from JavaScript."
                         }
                     )
 
-        JavascriptSentBatchResponse { request, pathId, ids } ->
+        JavascriptSentBatchResponse { resolverId, pathId, ids } ->
             case Dict.get pathId model.batchResponseDict of
-                Just onResponse ->
+                Just listOfHandlers ->
                     ( { model | batchResponseDict = Dict.remove pathId model.batchResponseDict }
-                    , onResponse ids
+                    , Cmd.batch (List.map (\onResponse -> onResponse ids) listOfHandlers)
                     )
 
                 Nothing ->
                     ( model
                     , Ports.failure
-                        { request = request
+                        { resolverId = resolverId
                         , reason = "Unexpected batch response from JavaScript."
                         }
                     )

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -96,6 +96,7 @@ runResolver resolverId request =
             createResolver
                 { resolverId = resolverId
                 , request = request
+                , info = info
                 , parentDecoder = Json.Decode.succeed ()
                 , argsDecoder = Resolvers.Query.Hello.argumentDecoder
                 , resolver = Resolvers.Query.Hello.resolver
@@ -106,6 +107,7 @@ runResolver resolverId request =
             createResolver
                 { resolverId = resolverId
                 , request = request
+                , info = info
                 , parentDecoder = Json.Decode.succeed ()
                 , argsDecoder = Resolvers.Query.User.argumentsDecoder
                 , resolver = Resolvers.Query.User.resolver info
@@ -116,6 +118,7 @@ runResolver resolverId request =
             createResolver
                 { resolverId = resolverId
                 , request = request
+                , info = info
                 , parentDecoder = Json.Decode.succeed ()
                 , argsDecoder = Json.Decode.succeed ()
                 , resolver = Resolvers.Query.Users.resolver info
@@ -126,6 +129,7 @@ runResolver resolverId request =
             createResolver
                 { resolverId = resolverId
                 , request = request
+                , info = info
                 , parentDecoder = Json.Decode.succeed ()
                 , argsDecoder = Resolvers.Query.Post.argumentsDecoder
                 , resolver = Resolvers.Query.Post.resolver info
@@ -136,6 +140,7 @@ runResolver resolverId request =
             createResolver
                 { resolverId = resolverId
                 , request = request
+                , info = info
                 , parentDecoder = Json.Decode.succeed ()
                 , argsDecoder = Json.Decode.succeed ()
                 , resolver = Resolvers.Query.Posts.resolver
@@ -146,6 +151,7 @@ runResolver resolverId request =
             createResolver
                 { resolverId = resolverId
                 , request = request
+                , info = info
                 , parentDecoder = Json.Decode.succeed ()
                 , argsDecoder = Resolvers.Mutation.CreatePost.argumentsDecoder
                 , resolver = Resolvers.Mutation.CreatePost.resolver info context
@@ -156,6 +162,7 @@ runResolver resolverId request =
             createResolver
                 { resolverId = resolverId
                 , request = request
+                , info = info
                 , parentDecoder = Json.Decode.succeed ()
                 , argsDecoder = Resolvers.Mutation.UpdatePost.argumentsDecoder
                 , resolver = Resolvers.Mutation.UpdatePost.resolver info
@@ -166,6 +173,7 @@ runResolver resolverId request =
             createResolver
                 { resolverId = resolverId
                 , request = request
+                , info = info
                 , parentDecoder = Json.Decode.succeed ()
                 , argsDecoder = Resolvers.Mutation.DeletePost.argumentsDecoder
                 , resolver = Resolvers.Mutation.DeletePost.resolver info
@@ -176,6 +184,7 @@ runResolver resolverId request =
             createResolver
                 { resolverId = resolverId
                 , request = request
+                , info = info
                 , parentDecoder = Json.Decode.succeed ()
                 , argsDecoder = Resolvers.Mutation.CreateUser.argumentsDecoder
                 , resolver = Resolvers.Mutation.CreateUser.resolver info
@@ -186,6 +195,7 @@ runResolver resolverId request =
             createResolver
                 { resolverId = resolverId
                 , request = request
+                , info = info
                 , parentDecoder = Json.Decode.succeed ()
                 , argsDecoder = Resolvers.Mutation.UpdateUser.argumentsDecoder
                 , resolver = Resolvers.Mutation.UpdateUser.resolver info
@@ -196,6 +206,7 @@ runResolver resolverId request =
             createResolver
                 { resolverId = resolverId
                 , request = request
+                , info = info
                 , parentDecoder = Json.Decode.succeed ()
                 , argsDecoder = Resolvers.Mutation.DeleteUser.argumentsDecoder
                 , resolver = Resolvers.Mutation.DeleteUser.resolver info
@@ -206,6 +217,7 @@ runResolver resolverId request =
             createResolver
                 { resolverId = resolverId
                 , request = request
+                , info = info
                 , parentDecoder = Schema.User.decoder
                 , argsDecoder = Json.Decode.succeed ()
                 , resolver = Resolvers.User.Id.resolver
@@ -216,6 +228,7 @@ runResolver resolverId request =
             createResolver
                 { resolverId = resolverId
                 , request = request
+                , info = info
                 , parentDecoder = Schema.User.decoder
                 , argsDecoder = Json.Decode.succeed ()
                 , resolver = Resolvers.User.Username.resolver
@@ -226,6 +239,7 @@ runResolver resolverId request =
             createResolver
                 { resolverId = resolverId
                 , request = request
+                , info = info
                 , parentDecoder = Schema.User.decoder
                 , argsDecoder = Json.Decode.succeed ()
                 , resolver = Resolvers.User.AvatarUrl.resolver
@@ -236,6 +250,7 @@ runResolver resolverId request =
             createResolver
                 { resolverId = resolverId
                 , request = request
+                , info = info
                 , parentDecoder = Schema.User.decoder
                 , argsDecoder = Json.Decode.succeed ()
                 , resolver = Resolvers.User.Posts.resolver
@@ -246,6 +261,7 @@ runResolver resolverId request =
             createResolver
                 { resolverId = resolverId
                 , request = request
+                , info = info
                 , parentDecoder = Schema.Post.decoder
                 , argsDecoder = Json.Decode.succeed ()
                 , resolver = Resolvers.Post.Id.resolver
@@ -256,6 +272,7 @@ runResolver resolverId request =
             createResolver
                 { resolverId = resolverId
                 , request = request
+                , info = info
                 , parentDecoder = Schema.Post.decoder
                 , argsDecoder = Json.Decode.succeed ()
                 , resolver = Resolvers.Post.ImageUrls.resolver
@@ -266,6 +283,7 @@ runResolver resolverId request =
             createResolver
                 { resolverId = resolverId
                 , request = request
+                , info = info
                 , parentDecoder = Schema.Post.decoder
                 , argsDecoder = Json.Decode.succeed ()
                 , resolver = Resolvers.Post.Caption.resolver
@@ -276,6 +294,7 @@ runResolver resolverId request =
             createResolver
                 { resolverId = resolverId
                 , request = request
+                , info = info
                 , parentDecoder = Schema.Post.decoder
                 , argsDecoder = Json.Decode.succeed ()
                 , resolver = Resolvers.Post.CreatedAt.resolver
@@ -286,6 +305,7 @@ runResolver resolverId request =
             createResolver
                 { resolverId = resolverId
                 , request = request
+                , info = info
                 , parentDecoder = Schema.Post.decoder
                 , argsDecoder = Json.Decode.succeed ()
                 , resolver = Resolvers.Post.Author.resolver info
@@ -310,6 +330,7 @@ runResolver resolverId request =
 
 createResolver :
     { resolverId : ResolverId
+    , info : Info
     , request : Json.Decode.Value
     , parentDecoder : Json.Decode.Decoder parent
     , argsDecoder : Json.Decode.Decoder args
@@ -341,8 +362,13 @@ createResolver options =
                                 { resolverId = options.resolverId
                                 , reason = reason
                                 }
-                    , onDatabaseQuery = ElmSentDatabaseQuery options.resolverId
-                    , onBatchQuery = ElmSentBatchRequest options.resolverId
+                    , onDatabaseQuery =
+                        ElmSentDatabaseQuery
+                            options.resolverId
+                            (GraphQL.Info.toBatchId options.info)
+                    , onBatchQuery =
+                        ElmSentBatchRequest
+                            options.resolverId
                     }
 
         Err _ ->
@@ -359,6 +385,7 @@ createResolver options =
 type Msg
     = ElmSentDatabaseQuery
         ResolverId
+        BatchResolverId
         { sql : String
         , onResponse : Json.Decode.Value -> Cmd Msg
         }
@@ -374,7 +401,7 @@ type Msg
         }
     | JavascriptSentBatchResponse
         { resolverId : ResolverId
-        , pathId : BatchResolverId
+        , batchId : BatchResolverId
         , ids : List Int
         }
     | JavascriptRequestedResolver
@@ -387,10 +414,11 @@ update : Msg -> Model -> ( Model, Cmd Msg )
 update msg model =
     case msg of
         -- case Debug.log "msg" msg of
-        ElmSentDatabaseQuery resolverId options ->
+        ElmSentDatabaseQuery resolverId batchId options ->
             ( { model | databaseResponseDict = AssocList.insert resolverId options.onResponse model.databaseResponseDict }
             , Ports.databaseOut
                 { resolverId = resolverId
+                , batchId = batchId
                 , sql = options.sql
                 }
             )
@@ -404,11 +432,11 @@ update msg model =
                         |> (\list -> options.onResponse :: list)
                         |> Just
             in
-            ( { model | batchResponseDict = Dict.update (GraphQL.Info.toPathId options.info) addCmdToList model.batchResponseDict }
+            ( { model | batchResponseDict = Dict.update (GraphQL.Info.toBatchId options.info) addCmdToList model.batchResponseDict }
             , Ports.batchRequestOut
                 { resolverId = resolverId
                 , id = options.id
-                , pathId = GraphQL.Info.toPathId options.info
+                , batchId = GraphQL.Info.toBatchId options.info
                 }
             )
 
@@ -432,10 +460,10 @@ update msg model =
                         }
                     )
 
-        JavascriptSentBatchResponse { resolverId, pathId, ids } ->
-            case Dict.get pathId model.batchResponseDict of
+        JavascriptSentBatchResponse { resolverId, batchId, ids } ->
+            case Dict.get batchId model.batchResponseDict of
                 Just listOfHandlers ->
-                    ( { model | batchResponseDict = Dict.remove pathId model.batchResponseDict }
+                    ( { model | batchResponseDict = Dict.remove batchId model.batchResponseDict }
                     , Cmd.batch (List.map (\onResponse -> onResponse ids) listOfHandlers)
                     )
 

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -110,7 +110,7 @@ runResolver resolverId request =
                 , info = info
                 , parentDecoder = Json.Decode.succeed ()
                 , argsDecoder = Resolvers.Query.User.argumentsDecoder
-                , resolver = Resolvers.Query.User.resolver info
+                , resolver = Resolvers.Query.User.resolver
                 , toJson = Json.Encode.Extra.maybe Schema.User.encode
                 }
 
@@ -121,7 +121,7 @@ runResolver resolverId request =
                 , info = info
                 , parentDecoder = Json.Decode.succeed ()
                 , argsDecoder = Json.Decode.succeed ()
-                , resolver = Resolvers.Query.Users.resolver info
+                , resolver = Resolvers.Query.Users.resolver
                 , toJson = Json.Encode.list Schema.User.encode
                 }
 
@@ -132,7 +132,7 @@ runResolver resolverId request =
                 , info = info
                 , parentDecoder = Json.Decode.succeed ()
                 , argsDecoder = Resolvers.Query.Post.argumentsDecoder
-                , resolver = Resolvers.Query.Post.resolver info
+                , resolver = Resolvers.Query.Post.resolver
                 , toJson = Json.Encode.Extra.maybe Schema.Post.encode
                 }
 
@@ -154,7 +154,7 @@ runResolver resolverId request =
                 , info = info
                 , parentDecoder = Json.Decode.succeed ()
                 , argsDecoder = Resolvers.Mutation.CreatePost.argumentsDecoder
-                , resolver = Resolvers.Mutation.CreatePost.resolver info context
+                , resolver = Resolvers.Mutation.CreatePost.resolver context
                 , toJson = Schema.Post.encode
                 }
 
@@ -165,7 +165,7 @@ runResolver resolverId request =
                 , info = info
                 , parentDecoder = Json.Decode.succeed ()
                 , argsDecoder = Resolvers.Mutation.UpdatePost.argumentsDecoder
-                , resolver = Resolvers.Mutation.UpdatePost.resolver info
+                , resolver = Resolvers.Mutation.UpdatePost.resolver
                 , toJson = Json.Encode.Extra.maybe Schema.Post.encode
                 }
 
@@ -176,7 +176,7 @@ runResolver resolverId request =
                 , info = info
                 , parentDecoder = Json.Decode.succeed ()
                 , argsDecoder = Resolvers.Mutation.DeletePost.argumentsDecoder
-                , resolver = Resolvers.Mutation.DeletePost.resolver info
+                , resolver = Resolvers.Mutation.DeletePost.resolver
                 , toJson = Json.Encode.Extra.maybe Schema.Post.encode
                 }
 
@@ -187,7 +187,7 @@ runResolver resolverId request =
                 , info = info
                 , parentDecoder = Json.Decode.succeed ()
                 , argsDecoder = Resolvers.Mutation.CreateUser.argumentsDecoder
-                , resolver = Resolvers.Mutation.CreateUser.resolver info
+                , resolver = Resolvers.Mutation.CreateUser.resolver
                 , toJson = Schema.User.encode
                 }
 
@@ -198,7 +198,7 @@ runResolver resolverId request =
                 , info = info
                 , parentDecoder = Json.Decode.succeed ()
                 , argsDecoder = Resolvers.Mutation.UpdateUser.argumentsDecoder
-                , resolver = Resolvers.Mutation.UpdateUser.resolver info
+                , resolver = Resolvers.Mutation.UpdateUser.resolver
                 , toJson = Json.Encode.Extra.maybe Schema.User.encode
                 }
 
@@ -209,7 +209,7 @@ runResolver resolverId request =
                 , info = info
                 , parentDecoder = Json.Decode.succeed ()
                 , argsDecoder = Resolvers.Mutation.DeleteUser.argumentsDecoder
-                , resolver = Resolvers.Mutation.DeleteUser.resolver info
+                , resolver = Resolvers.Mutation.DeleteUser.resolver
                 , toJson = Json.Encode.Extra.maybe Schema.User.encode
                 }
 
@@ -253,7 +253,7 @@ runResolver resolverId request =
                 , info = info
                 , parentDecoder = Schema.User.decoder
                 , argsDecoder = Json.Decode.succeed ()
-                , resolver = Resolvers.User.Posts.resolver
+                , resolver = Resolvers.User.Posts.resolver info
                 , toJson = Json.Encode.list Schema.Post.encode
                 }
 

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -55,7 +55,7 @@ type alias Model =
 init : Json.Decode.Value -> ( Model, Cmd Msg )
 init flags =
     ( { onResponse = Nothing }
-    , runResolver flags
+    , Cmd.none
     )
 
 
@@ -332,6 +332,9 @@ type Msg
         { request : Json.Decode.Value
         , response : Json.Decode.Value
         }
+    | JavascriptRequestedResolver
+        { request : Json.Decode.Value
+        }
 
 
 update : Msg -> Model -> ( Model, Cmd Msg )
@@ -343,6 +346,11 @@ update msg model =
                 { request = request
                 , sql = options.sql
                 }
+            )
+
+        JavascriptRequestedResolver { request } ->
+            ( model
+            , runResolver request
             )
 
         JavascriptSentDatabaseResponse { request, response } ->
@@ -367,4 +375,7 @@ update msg model =
 
 subscriptions : Model -> Sub Msg
 subscriptions _ =
-    Ports.databaseIn JavascriptSentDatabaseResponse
+    Sub.batch
+        [ Ports.databaseIn JavascriptSentDatabaseResponse
+        , Ports.runResolver JavascriptRequestedResolver
+        ]

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -1,6 +1,6 @@
 module Main exposing (main)
 
-import Dict exposing (Dict)
+import AssocList exposing (Dict)
 import GraphQL.Context
 import GraphQL.Info
 import GraphQL.Response exposing (Response)
@@ -48,13 +48,13 @@ main =
 
 
 type alias Model =
-    { onResponse : Maybe (Json.Decode.Value -> Cmd Msg)
+    { onResponse : Dict Json.Decode.Value (Json.Decode.Value -> Cmd Msg)
     }
 
 
 init : Json.Decode.Value -> ( Model, Cmd Msg )
 init flags =
-    ( { onResponse = Nothing }
+    ( { onResponse = AssocList.empty }
     , Cmd.none
     )
 
@@ -341,7 +341,7 @@ update : Msg -> Model -> ( Model, Cmd Msg )
 update msg model =
     case msg of
         ResolverSentDatabaseQuery request options ->
-            ( { model | onResponse = Just options.onResponse }
+            ( { model | onResponse = AssocList.insert request options.onResponse model.onResponse }
             , Ports.databaseOut
                 { request = request
                 , sql = options.sql
@@ -354,9 +354,9 @@ update msg model =
             )
 
         JavascriptSentDatabaseResponse { request, response } ->
-            case model.onResponse of
+            case AssocList.get request model.onResponse of
                 Just onResponse ->
-                    ( { model | onResponse = Nothing }
+                    ( { model | onResponse = AssocList.remove request model.onResponse }
                     , onResponse response
                     )
 

--- a/src/Ports.elm
+++ b/src/Ports.elm
@@ -41,7 +41,7 @@ failure options =
 batchRequestOut :
     { resolverId : String
     , id : Int
-    , pathId : String
+    , batchId : String
     }
     -> Cmd msg
 batchRequestOut options =
@@ -51,13 +51,14 @@ batchRequestOut options =
         , payload =
             Json.Encode.object
                 [ ( "id", Json.Encode.int options.id )
-                , ( "pathId", Json.Encode.string options.pathId )
+                , ( "batchId", Json.Encode.string options.batchId )
                 ]
         }
 
 
 databaseOut :
     { resolverId : String
+    , batchId : String
     , sql : String
     }
     -> Cmd msg
@@ -65,7 +66,11 @@ databaseOut options =
     outgoing
         { tag = "DATABASE_OUT"
         , resolverId = options.resolverId
-        , payload = Json.Encode.string options.sql
+        , payload =
+            Json.Encode.object
+                [ ( "sql", Json.Encode.string options.sql )
+                , ( "batchId", Json.Encode.string options.batchId )
+                ]
         }
 
 
@@ -80,7 +85,7 @@ port databaseIn :
 
 port batchIn :
     ({ resolverId : String
-     , pathId : String
+     , batchId : String
      , ids : List Int
      }
      -> msg

--- a/src/Ports.elm
+++ b/src/Ports.elm
@@ -1,15 +1,60 @@
 port module Ports exposing (databaseIn, databaseOut, failure, success)
 
 import Json.Decode
+import Json.Encode
 
 
-port success : Json.Decode.Value -> Cmd msg
+success :
+    { request : Json.Decode.Value
+    , value : Json.Decode.Value
+    }
+    -> Cmd msg
+success options =
+    outgoing
+        { tag = "SUCCESS"
+        , request = options.request
+        , payload = options.value
+        }
 
 
-port failure : Json.Decode.Value -> Cmd msg
+failure :
+    { request : Json.Decode.Value
+    , reason : String
+    }
+    -> Cmd msg
+failure options =
+    outgoing
+        { tag = "FAILURE"
+        , request = options.request
+        , payload = Json.Encode.string options.reason
+        }
 
 
-port databaseOut : { sql : String } -> Cmd msg
+databaseOut :
+    { request : Json.Decode.Value
+    , sql : String
+    }
+    -> Cmd msg
+databaseOut options =
+    outgoing
+        { tag = "DATABASE_OUT"
+        , request = options.request
+        , payload = Json.Encode.string options.sql
+        }
 
 
-port databaseIn : ({ response : Json.Decode.Value } -> msg) -> Sub msg
+port databaseIn :
+    ({ request : Json.Decode.Value
+     , response : Json.Decode.Value
+     }
+     -> msg
+    )
+    -> Sub msg
+
+
+port outgoing :
+    { request : Json.Decode.Value
+    , tag : String
+    , payload : Json.Decode.Value
+    }
+    -> Cmd msg

--- a/src/Ports.elm
+++ b/src/Ports.elm
@@ -1,4 +1,12 @@
-port module Ports exposing (databaseIn, databaseOut, failure, runResolver, success)
+port module Ports exposing
+    ( batchIn
+    , batchRequestOut
+    , databaseIn
+    , databaseOut
+    , failure
+    , runResolver
+    , success
+    )
 
 import Json.Decode
 import Json.Encode
@@ -30,6 +38,24 @@ failure options =
         }
 
 
+batchRequestOut :
+    { request : Json.Decode.Value
+    , id : Int
+    , pathId : String
+    }
+    -> Cmd msg
+batchRequestOut options =
+    outgoing
+        { tag = "BATCH_OUT"
+        , request = options.request
+        , payload =
+            Json.Encode.object
+                [ ( "id", Json.Encode.int options.id )
+                , ( "pathId", Json.Encode.string options.pathId )
+                ]
+        }
+
+
 databaseOut :
     { request : Json.Decode.Value
     , sql : String
@@ -46,6 +72,16 @@ databaseOut options =
 port databaseIn :
     ({ request : Json.Decode.Value
      , response : Json.Decode.Value
+     }
+     -> msg
+    )
+    -> Sub msg
+
+
+port batchIn :
+    ({ request : Json.Decode.Value
+     , pathId : String
+     , ids : List Int
      }
      -> msg
     )

--- a/src/Ports.elm
+++ b/src/Ports.elm
@@ -1,4 +1,4 @@
-port module Ports exposing (databaseIn, databaseOut, failure, success)
+port module Ports exposing (databaseIn, databaseOut, failure, runResolver, success)
 
 import Json.Decode
 import Json.Encode
@@ -46,6 +46,14 @@ databaseOut options =
 port databaseIn :
     ({ request : Json.Decode.Value
      , response : Json.Decode.Value
+     }
+     -> msg
+    )
+    -> Sub msg
+
+
+port runResolver :
+    ({ request : Json.Decode.Value
      }
      -> msg
     )

--- a/src/Ports.elm
+++ b/src/Ports.elm
@@ -13,33 +13,33 @@ import Json.Encode
 
 
 success :
-    { request : Json.Decode.Value
+    { resolverId : String
     , value : Json.Decode.Value
     }
     -> Cmd msg
 success options =
     outgoing
         { tag = "SUCCESS"
-        , request = options.request
+        , resolverId = options.resolverId
         , payload = options.value
         }
 
 
 failure :
-    { request : Json.Decode.Value
+    { resolverId : String
     , reason : String
     }
     -> Cmd msg
 failure options =
     outgoing
         { tag = "FAILURE"
-        , request = options.request
+        , resolverId = options.resolverId
         , payload = Json.Encode.string options.reason
         }
 
 
 batchRequestOut :
-    { request : Json.Decode.Value
+    { resolverId : String
     , id : Int
     , pathId : String
     }
@@ -47,7 +47,7 @@ batchRequestOut :
 batchRequestOut options =
     outgoing
         { tag = "BATCH_OUT"
-        , request = options.request
+        , resolverId = options.resolverId
         , payload =
             Json.Encode.object
                 [ ( "id", Json.Encode.int options.id )
@@ -57,20 +57,20 @@ batchRequestOut options =
 
 
 databaseOut :
-    { request : Json.Decode.Value
+    { resolverId : String
     , sql : String
     }
     -> Cmd msg
 databaseOut options =
     outgoing
         { tag = "DATABASE_OUT"
-        , request = options.request
+        , resolverId = options.resolverId
         , payload = Json.Encode.string options.sql
         }
 
 
 port databaseIn :
-    ({ request : Json.Decode.Value
+    ({ resolverId : String
      , response : Json.Decode.Value
      }
      -> msg
@@ -79,7 +79,7 @@ port databaseIn :
 
 
 port batchIn :
-    ({ request : Json.Decode.Value
+    ({ resolverId : String
      , pathId : String
      , ids : List Int
      }
@@ -89,7 +89,8 @@ port batchIn :
 
 
 port runResolver :
-    ({ request : Json.Decode.Value
+    ({ resolverId : String
+     , request : Json.Decode.Value
      }
      -> msg
     )
@@ -97,7 +98,7 @@ port runResolver :
 
 
 port outgoing :
-    { request : Json.Decode.Value
+    { resolverId : String
     , tag : String
     , payload : Json.Decode.Value
     }

--- a/src/Resolvers/Mutation/CreatePost.elm
+++ b/src/Resolvers/Mutation/CreatePost.elm
@@ -28,8 +28,8 @@ argumentsDecoder =
         (Json.Decode.field "caption" Json.Decode.string)
 
 
-resolver : Info -> Context -> () -> Arguments -> GraphQL.Response.Response Post
-resolver info context _ args =
+resolver : Context -> () -> Arguments -> GraphQL.Response.Response Post
+resolver context _ args =
     case context.currentUserId of
         Nothing ->
             GraphQL.Response.err "Must be signed in to create a post."

--- a/src/Resolvers/Mutation/CreatePost.elm
+++ b/src/Resolvers/Mutation/CreatePost.elm
@@ -35,12 +35,7 @@ resolver info context _ args =
             GraphQL.Response.err "Must be signed in to create a post."
 
         Just currentUserId ->
-            if GraphQL.Info.hasSelection "author" info then
-                createPostAndEdge args currentUserId
-                    |> GraphQL.Response.andThen Resolvers.Post.Author.include
-
-            else
-                createPostAndEdge args currentUserId
+            createPostAndEdge args currentUserId
 
 
 createPostAndEdge : Arguments -> Int -> GraphQL.Response.Response Post

--- a/src/Resolvers/Mutation/CreateUser.elm
+++ b/src/Resolvers/Mutation/CreateUser.elm
@@ -23,22 +23,13 @@ argumentsDecoder =
         (Json.Decode.maybe (Json.Decode.field "avatarUrl" Json.Decode.string))
 
 
-resolver : Info -> () -> Arguments -> GraphQL.Response.Response User
-resolver info _ args =
-    let
-        insertUser =
-            Table.Users.insertOne
-                { values =
-                    [ Table.Users.Value.username args.username
-                    , Table.Users.Value.avatarUrl args.avatarUrl
-                    ]
-                , returning = Schema.User.selectAll
-                }
-                |> GraphQL.Response.fromDatabaseQuery
-    in
-    if GraphQL.Info.hasSelection "posts" info then
-        insertUser
-            |> GraphQL.Response.andThen Resolvers.User.Posts.include
-
-    else
-        insertUser
+resolver : () -> Arguments -> GraphQL.Response.Response User
+resolver _ args =
+    Table.Users.insertOne
+        { values =
+            [ Table.Users.Value.username args.username
+            , Table.Users.Value.avatarUrl args.avatarUrl
+            ]
+        , returning = Schema.User.selectAll
+        }
+        |> GraphQL.Response.fromDatabaseQuery

--- a/src/Resolvers/Mutation/DeletePost.elm
+++ b/src/Resolvers/Mutation/DeletePost.elm
@@ -22,8 +22,8 @@ argumentsDecoder =
         (Json.Decode.field "id" Json.Decode.int)
 
 
-resolver : Info -> () -> Arguments -> GraphQL.Response.Response (Maybe Post)
-resolver info _ args =
+resolver : () -> Arguments -> GraphQL.Response.Response (Maybe Post)
+resolver _ args =
     Table.Posts.deleteOne
         { where_ = Just (Table.Posts.Where.Id.equals args.id)
         , returning = Schema.Post.selectAll

--- a/src/Resolvers/Mutation/DeletePost.elm
+++ b/src/Resolvers/Mutation/DeletePost.elm
@@ -24,18 +24,8 @@ argumentsDecoder =
 
 resolver : Info -> () -> Arguments -> GraphQL.Response.Response (Maybe Post)
 resolver info _ args =
-    let
-        deletePost : GraphQL.Response.Response (Maybe Post)
-        deletePost =
-            Table.Posts.deleteOne
-                { where_ = Just (Table.Posts.Where.Id.equals args.id)
-                , returning = Schema.Post.selectAll
-                }
-                |> GraphQL.Response.fromDatabaseQuery
-    in
-    if GraphQL.Info.hasSelection "author" info then
-        deletePost
-            |> GraphQL.Response.andThen Resolvers.Post.Author.includeForMaybe
-
-    else
-        deletePost
+    Table.Posts.deleteOne
+        { where_ = Just (Table.Posts.Where.Id.equals args.id)
+        , returning = Schema.Post.selectAll
+        }
+        |> GraphQL.Response.fromDatabaseQuery

--- a/src/Resolvers/Mutation/DeleteUser.elm
+++ b/src/Resolvers/Mutation/DeleteUser.elm
@@ -22,19 +22,10 @@ argumentsDecoder =
         (Json.Decode.field "id" Json.Decode.int)
 
 
-resolver : Info -> () -> Arguments -> GraphQL.Response.Response (Maybe User)
-resolver info _ args =
-    let
-        deleteUser =
-            Table.Users.deleteOne
-                { where_ = Just (Table.Users.Where.Id.equals args.id)
-                , returning = Schema.User.selectAll
-                }
-                |> GraphQL.Response.fromDatabaseQuery
-    in
-    if GraphQL.Info.hasSelection "posts" info then
-        deleteUser
-            |> GraphQL.Response.andThen Resolvers.User.Posts.includeForMaybe
-
-    else
-        deleteUser
+resolver : () -> Arguments -> GraphQL.Response.Response (Maybe User)
+resolver _ args =
+    Table.Users.deleteOne
+        { where_ = Just (Table.Users.Where.Id.equals args.id)
+        , returning = Schema.User.selectAll
+        }
+        |> GraphQL.Response.fromDatabaseQuery

--- a/src/Resolvers/Mutation/UpdatePost.elm
+++ b/src/Resolvers/Mutation/UpdatePost.elm
@@ -27,8 +27,8 @@ argumentsDecoder =
         (Optional.decoder "caption" Json.Decode.string)
 
 
-resolver : Info -> () -> Arguments -> GraphQL.Response.Response (Maybe Post)
-resolver info _ args =
+resolver : () -> Arguments -> GraphQL.Response.Response (Maybe Post)
+resolver _ args =
     Table.Posts.updateOne
         { set =
             Optional.toList

--- a/src/Resolvers/Mutation/UpdatePost.elm
+++ b/src/Resolvers/Mutation/UpdatePost.elm
@@ -29,23 +29,13 @@ argumentsDecoder =
 
 resolver : Info -> () -> Arguments -> GraphQL.Response.Response (Maybe Post)
 resolver info _ args =
-    let
-        updatePost : GraphQL.Response.Response (Maybe Post)
-        updatePost =
-            Table.Posts.updateOne
-                { set =
-                    Optional.toList
-                        [ args.imageUrls |> Optional.map Table.Posts.Value.imageUrls
-                        , args.caption |> Optional.map Table.Posts.Value.caption
-                        ]
-                , where_ = Just (Table.Posts.Where.Id.equals args.id)
-                , returning = Schema.Post.selectAll
-                }
-                |> GraphQL.Response.fromDatabaseQuery
-    in
-    if GraphQL.Info.hasSelection "author" info then
-        updatePost
-            |> GraphQL.Response.andThen Resolvers.Post.Author.includeForMaybe
-
-    else
-        updatePost
+    Table.Posts.updateOne
+        { set =
+            Optional.toList
+                [ args.imageUrls |> Optional.map Table.Posts.Value.imageUrls
+                , args.caption |> Optional.map Table.Posts.Value.caption
+                ]
+        , where_ = Just (Table.Posts.Where.Id.equals args.id)
+        , returning = Schema.Post.selectAll
+        }
+        |> GraphQL.Response.fromDatabaseQuery

--- a/src/Resolvers/Mutation/UpdateUser.elm
+++ b/src/Resolvers/Mutation/UpdateUser.elm
@@ -27,24 +27,15 @@ argumentsDecoder =
         (Optional.decoder "avatarUrl" (Json.Decode.maybe Json.Decode.string))
 
 
-resolver : Info -> () -> Arguments -> GraphQL.Response.Response (Maybe User)
-resolver info _ args =
-    let
-        updateUser =
-            Table.Users.updateOne
-                { set =
-                    Optional.toList
-                        [ args.username |> Optional.map Table.Users.Value.username
-                        , args.avatarUrl |> Optional.map Table.Users.Value.avatarUrl
-                        ]
-                , where_ = Just (Table.Users.Where.Id.equals args.id)
-                , returning = Schema.User.selectAll
-                }
-                |> GraphQL.Response.fromDatabaseQuery
-    in
-    if GraphQL.Info.hasSelection "posts" info then
-        updateUser
-            |> GraphQL.Response.andThen Resolvers.User.Posts.includeForMaybe
-
-    else
-        updateUser
+resolver : () -> Arguments -> GraphQL.Response.Response (Maybe User)
+resolver _ args =
+    Table.Users.updateOne
+        { set =
+            Optional.toList
+                [ args.username |> Optional.map Table.Users.Value.username
+                , args.avatarUrl |> Optional.map Table.Users.Value.avatarUrl
+                ]
+        , where_ = Just (Table.Users.Where.Id.equals args.id)
+        , returning = Schema.User.selectAll
+        }
+        |> GraphQL.Response.fromDatabaseQuery

--- a/src/Resolvers/Query/Post.elm
+++ b/src/Resolvers/Query/Post.elm
@@ -25,18 +25,8 @@ argumentsDecoder =
 
 resolver : Info -> () -> Arguments -> Response (Maybe Post)
 resolver info parent args =
-    let
-        findPost : Response (Maybe Post)
-        findPost =
-            Table.Posts.findOne
-                { where_ = Just (Table.Posts.Where.Id.equals args.id)
-                , select = Schema.Post.selectAll
-                }
-                |> GraphQL.Response.fromDatabaseQuery
-    in
-    if GraphQL.Info.hasSelection "author" info then
-        findPost
-            |> GraphQL.Response.andThen Resolvers.Post.Author.includeForMaybe
-
-    else
-        findPost
+    Table.Posts.findOne
+        { where_ = Just (Table.Posts.Where.Id.equals args.id)
+        , select = Schema.Post.selectAll
+        }
+        |> GraphQL.Response.fromDatabaseQuery

--- a/src/Resolvers/Query/Post.elm
+++ b/src/Resolvers/Query/Post.elm
@@ -23,8 +23,8 @@ argumentsDecoder =
         (Json.Decode.field "id" Json.Decode.int)
 
 
-resolver : Info -> () -> Arguments -> Response (Maybe Post)
-resolver info parent args =
+resolver : () -> Arguments -> Response (Maybe Post)
+resolver parent args =
     Table.Posts.findOne
         { where_ = Just (Table.Posts.Where.Id.equals args.id)
         , select = Schema.Post.selectAll

--- a/src/Resolvers/Query/Posts.elm
+++ b/src/Resolvers/Query/Posts.elm
@@ -16,27 +16,13 @@ import Table.Users
 import Table.Users.Where.Id
 
 
-resolver : Info -> () -> () -> Response (List Post)
-resolver info _ args =
-    let
-        isSelectingAuthor : Bool
-        isSelectingAuthor =
-            GraphQL.Info.hasSelection "author" info
-
-        postsQuery : Response (List Post)
-        postsQuery =
-            Table.Posts.findAll
-                { select = Schema.Post.selectAll
-                , where_ = Nothing
-                , orderBy = Just (Database.Order.descending Table.Posts.Column.createdAt)
-                , limit = Just 25
-                , offset = Nothing
-                }
-                |> GraphQL.Response.fromDatabaseQuery
-    in
-    if isSelectingAuthor then
-        postsQuery
-            |> GraphQL.Response.andThen Resolvers.Post.Author.includeForList
-
-    else
-        postsQuery
+resolver : () -> () -> Response (List Post)
+resolver _ args =
+    Table.Posts.findAll
+        { select = Schema.Post.selectAll
+        , where_ = Nothing
+        , orderBy = Just (Database.Order.descending Table.Posts.Column.createdAt)
+        , limit = Just 25
+        , offset = Nothing
+        }
+        |> GraphQL.Response.fromDatabaseQuery

--- a/src/Resolvers/Query/User.elm
+++ b/src/Resolvers/Query/User.elm
@@ -23,19 +23,10 @@ argumentsDecoder =
         (Json.Decode.field "id" Json.Decode.int)
 
 
-resolver : Info -> () -> Arguments -> Response (Maybe User)
-resolver info _ args =
-    let
-        fetchUser =
-            Table.Users.findOne
-                { where_ = Just (Table.Users.Where.Id.equals args.id)
-                , select = Schema.User.selectAll
-                }
-                |> GraphQL.Response.fromDatabaseQuery
-    in
-    if GraphQL.Info.hasSelection "posts" info then
-        fetchUser
-            |> GraphQL.Response.andThen Resolvers.User.Posts.includeForMaybe
-
-    else
-        fetchUser
+resolver : () -> Arguments -> Response (Maybe User)
+resolver _ args =
+    Table.Users.findOne
+        { where_ = Just (Table.Users.Where.Id.equals args.id)
+        , select = Schema.User.selectAll
+        }
+        |> GraphQL.Response.fromDatabaseQuery

--- a/src/Resolvers/Query/Users.elm
+++ b/src/Resolvers/Query/Users.elm
@@ -8,22 +8,13 @@ import Table.Users
 import Table.Users.Select
 
 
-resolver : Info -> () -> () -> Response (List User)
-resolver info _ args =
-    let
-        fetchUsers =
-            Table.Users.findAll
-                { where_ = Nothing
-                , limit = Just 25
-                , offset = Nothing
-                , orderBy = Nothing
-                , select = Schema.User.selectAll
-                }
-                |> GraphQL.Response.fromDatabaseQuery
-    in
-    if GraphQL.Info.hasSelection "posts" info then
-        fetchUsers
-            |> GraphQL.Response.andThen Resolvers.User.Posts.includeForList
-
-    else
-        fetchUsers
+resolver : () -> () -> Response (List User)
+resolver _ args =
+    Table.Users.findAll
+        { where_ = Nothing
+        , limit = Just 25
+        , offset = Nothing
+        , orderBy = Nothing
+        , select = Schema.User.selectAll
+        }
+        |> GraphQL.Response.fromDatabaseQuery

--- a/src/Resolvers/User/Posts.elm
+++ b/src/Resolvers/User/Posts.elm
@@ -1,20 +1,10 @@
-module Resolvers.User.Posts exposing
-    ( resolver
-    , include, includeForList, includeForMaybe
-    )
-
-{-|
-
-@docs resolver
-
-@docs include, includeForList, includeForMaybe
-
--}
+module Resolvers.User.Posts exposing (resolver)
 
 import Database.Include
+import GraphQL.Info exposing (Info)
 import GraphQL.Response exposing (Response)
 import List.Extra
-import Schema
+import Schema exposing (Post, User)
 import Schema.Post
 import Schema.User
 import Schema.UserAuthoredPost exposing (UserAuthoredPost)
@@ -25,74 +15,72 @@ import Table.UserAuthoredPost.Where.UserId
 import Table.Users.Where.Id
 
 
-resolver : Schema.User -> () -> Response (List Schema.Post)
-resolver (Schema.User user) args =
-    GraphQL.Response.ok user.posts
+resolver : Info -> Schema.User -> () -> Response (List Post)
+resolver info (Schema.User user) args =
+    GraphQL.Response.batchList
+        { id = user.id
+        , info = info
+        , toBatchResponse = toBatchResponse
+        }
 
 
-include : Schema.User -> Response Schema.User
-include =
-    Database.Include.fromListToItem includeForList
+
+-- INTERNALS
 
 
-includeForMaybe : Maybe Schema.User -> Response (Maybe Schema.User)
-includeForMaybe =
-    Database.Include.fromListToMaybe includeForList
+toBatchResponse : List Int -> Response (List (List Post))
+toBatchResponse userIds =
+    fetchUserAuthoredPostEdges userIds
+        |> GraphQL.Response.andThen (fetchPostsAndGroupByUserId userIds)
 
 
-includeForList : List Schema.User -> Response (List Schema.User)
-includeForList authors =
-    fetchUserAuthoredPostEdgesFor authors
-        |> GraphQL.Response.andThen (fetchPostsFor authors)
-
-
-fetchUserAuthoredPostEdgesFor : List Schema.User -> Response (List UserAuthoredPost)
-fetchUserAuthoredPostEdgesFor users =
+fetchUserAuthoredPostEdges : List Int -> Response (List UserAuthoredPost)
+fetchUserAuthoredPostEdges userIds =
     Table.UserAuthoredPost.findAll
         { select = Schema.UserAuthoredPost.selectAll
-        , where_ = Just (Table.UserAuthoredPost.Where.UserId.in_ (List.map Schema.User.id users))
         , limit = Nothing
         , offset = Nothing
         , orderBy = Nothing
+        , where_ = Just (Table.UserAuthoredPost.Where.UserId.in_ userIds)
         }
         |> GraphQL.Response.fromDatabaseQuery
 
 
-fetchPostsFor : List Schema.User -> List UserAuthoredPost -> Response (List Schema.User)
-fetchPostsFor users edges =
+fetchPosts : List UserAuthoredPost -> Response (List Post)
+fetchPosts edges =
     Table.Posts.findAll
         { select = Schema.Post.selectAll
         , limit = Nothing
-        , where_ = Just (Table.Posts.Where.Id.in_ (List.map .postId edges))
         , offset = Nothing
         , orderBy = Nothing
+        , where_ = Just (Table.Posts.Where.Id.in_ (List.map .postId edges))
         }
         |> GraphQL.Response.fromDatabaseQuery
-        |> GraphQL.Response.map (fillInPostsForAuthors users edges)
 
 
-fillInPostsForAuthors :
-    List Schema.User
-    -> List UserAuthoredPost
-    -> List Schema.Post
-    -> List Schema.User
-fillInPostsForAuthors users edges posts =
-    List.map (updateUserWithPosts edges posts) users
-
-
-updateUserWithPosts : List UserAuthoredPost -> List Schema.Post -> Schema.User -> Schema.User
-updateUserWithPosts edges posts (Schema.User user) =
+fetchPostsAndGroupByUserId : List Int -> List UserAuthoredPost -> Response (List (List Post))
+fetchPostsAndGroupByUserId userIds edges =
     let
-        edgesMatchingThisUser : List UserAuthoredPost
-        edgesMatchingThisUser =
-            List.filter (\edge -> edge.userId == user.id) edges
+        groupByUserId : List Post -> List (List Post)
+        groupByUserId posts =
+            List.map (postsByUserId posts) userIds
 
-        postsMatchingThisUser : List Schema.Post
-        postsMatchingThisUser =
-            List.filterMap findPostForEdge edgesMatchingThisUser
+        postsByUserId : List Post -> Int -> List Post
+        postsByUserId posts userId =
+            let
+                edgesMatchingThisUser : List UserAuthoredPost
+                edgesMatchingThisUser =
+                    List.filter (\edge -> edge.userId == userId) edges
 
-        findPostForEdge : UserAuthoredPost -> Maybe Schema.Post
-        findPostForEdge edge =
-            List.Extra.find (\(Schema.Post post) -> post.id == edge.postId) posts
+                postsMatchingThisUser : List Post
+                postsMatchingThisUser =
+                    List.concatMap findPostsForEdge edgesMatchingThisUser
+
+                findPostsForEdge : UserAuthoredPost -> List Post
+                findPostsForEdge edge =
+                    List.filter (\(Schema.Post post) -> post.id == edge.postId) posts
+            in
+            postsMatchingThisUser
     in
-    Schema.User { user | posts = postsMatchingThisUser }
+    fetchPosts edges
+        |> GraphQL.Response.map groupByUserId

--- a/src/index.js
+++ b/src/index.js
@@ -117,20 +117,15 @@ const fieldHandler = (objectName) => ({
               context.batchRequestIds[batchId] = []
 
               setTimeout(() => {
-                // console.log('Sending batch IDs for: ', context.batchRequestIds[batchId])
-
                 context.worker.ports.batchIn.send({
                   resolverId,
                   batchId,
                   ids: context.batchRequestIds[batchId]
                 })
-              }) // TODO: Find a smarter way to handle this
+              })
             }
 
             context.batchRequestIds[batchId].push(id)
-
-            // console.log(context.batchRequestIds[batchId])
-            
           }
         }
 

--- a/src/index.js
+++ b/src/index.js
@@ -61,7 +61,9 @@ const fieldHandler = (objectName) => ({
     if (fieldName === "__isTypeOf") return () => objectName
     return (parent, args, context, info) => {
       const request = { objectName, fieldName, parent, args, context, info }
-      const worker = Elm.Main.init({ flags: request })
+      const worker = Elm.Main.init()
+
+      worker.ports.runResolver.send({ request })
       
       return new Promise((resolve, reject) => {
         const handlers = {

--- a/src/index.js
+++ b/src/index.js
@@ -86,7 +86,7 @@ const fieldHandler = (objectName) => ({
 
             if (context.sqlCache[key]) {
               const cachedResponse = context.sqlCache[key].response
-              console.log('✅ Cache hit')
+
               if (cachedResponse) {
                 // If this SQL statement has already run, return the cached result
                 sendToElm(cachedResponse)

--- a/src/index.js
+++ b/src/index.js
@@ -89,15 +89,22 @@ const fieldHandler = (objectName) => ({
           SUCCESS: (value) => resolve(value),
           FAILURE: (reason) => reject(Error(reason)),
           DATABASE_OUT: async (sql) => {
-              console.log(`\n\n💾 ${sql}\n`)
-              let response = await context.db.all(sql)
-              console.table(response)
-      
-              worker.ports.databaseIn.send({ request, response })
+            console.log(`\n\n💾 ${sql}\n`)
+            let response = await context.db.all(sql)
+            console.table(response)
+    
+            worker.ports.databaseIn.send({ request, response })
           }
         }
 
         worker.ports.outgoing.subscribe(msg => {
+          // This conditional is critical for our resolver to work,
+          // because it ignores any Elm messages from other resolvers
+          // 
+          // WARNING: JS uses object references for equality. If anything
+          // freaky starts to happen– we should change this code to use
+          // something like an Integer ID, rather than comparing the full
+          // JSON request objects.
           if (msg.request === request) {
             const handler = handlers[msg.tag]
             if (handler) {


### PR DESCRIPTION
## Problem

Before, each GraphQL query and mutation was checking if it needed to fetch nested relationship fields (like `author` or `posts`). The way I was doing that:
- Was very tedious to write (`if GraphQL.Info.hasSelection "authors" then ... else ...`
- Did not support recursive nesting! `posts { author { posts { author { id } } } }`

Using a naive approach would lead to the __N + 1 problem__– generating a crazy amount of SQL queries for a simple page.

For some context, here's a really great intro to the problem/solution here:
https://www.youtube.com/watch?v=ld2_AS4l19g

## Solution

This set of changes uses the same strategy of Facebook's Data Loader– where `Post.author` and `User.posts` batch their IDs before actually sending SQL requests.

This means that we can request authors for users like this:

```sql
SELECT id, username FROM users WHERE userId IN ( 1, 2, 3 );
```

Instead of sending a SQL statement for each command:

```sql
SELECT id, username FROM users WHERE userId IN 1;
SELECT id, username FROM users WHERE userId IN 2;
SELECT id, username FROM users WHERE userId IN 3;
```

![image](https://user-images.githubusercontent.com/6187256/160306120-1e0bd962-2aa2-4ca0-8822-e909c7e1c199.png)

Each level of nesting will only run 2 SQL statements– regardless of how many posts or authors we have in our database!